### PR TITLE
Remove hardcoded Unix file path

### DIFF
--- a/src/models/layout_config.rs
+++ b/src/models/layout_config.rs
@@ -1,4 +1,5 @@
 use serde::Deserialize;
+use std::path::PathBuf;
 
 #[derive(Debug, Deserialize)]
 pub struct LayoutConfig {
@@ -9,8 +10,9 @@ pub struct LayoutConfig {
 
 impl Default for LayoutConfig {
     fn default() -> Self {
+        let path: PathBuf = [".", "examples", "fonts"].iter().collect();
         LayoutConfig {
-            font_location: "./examples/fonts/".to_string(),
+            font_location: path.into_os_string().into_string().unwrap(),
             font: "FiraSans".to_string(),
             font_size: "12pt".to_string(),
         }

--- a/tests/fixtures/expected.tex
+++ b/tests/fixtures/expected.tex
@@ -8,7 +8,7 @@
 \usepackage{enumitem}
 \defaultfontfeatures{Mapping=tex-text}
 \setmainfont{FiraSans}[
-    Path = ./examples/fonts/,
+    Path = ./examples/fonts,
     UprightFont = *-Regular,
     BoldFont = *-Bold,
 ]


### PR DESCRIPTION
This only addresses the hardcoded font location.

Some tests will still be broken on Windows, but we should leave that
to someone who has an interest in fixing this and can actually run
the tests on the Windows platform.

Fixes #26