### PR TITLE
Add trailing slash for font file path

### DIFF
--- a/src/models/layout_config.rs
+++ b/src/models/layout_config.rs
@@ -10,7 +10,7 @@ pub struct LayoutConfig {
 
 impl Default for LayoutConfig {
     fn default() -> Self {
-        let path: PathBuf = [".", "examples", "fonts"].iter().collect();
+        let path: PathBuf = [".", "examples", "fonts", ""].iter().collect();
         LayoutConfig {
             font_location: path.into_os_string().into_string().unwrap(),
             font: "FiraSans".to_string(),

--- a/tests/fixtures/expected.tex
+++ b/tests/fixtures/expected.tex
@@ -8,7 +8,7 @@
 \usepackage{enumitem}
 \defaultfontfeatures{Mapping=tex-text}
 \setmainfont{FiraSans}[
-    Path = ./examples/fonts,
+    Path = ./examples/fonts/,
     UprightFont = *-Regular,
     BoldFont = *-Bold,
 ]


### PR DESCRIPTION
It's not explicitly mentioned in the [documentation](http://ftp.uni-erlangen.de/ctan/macros/latex/contrib/fontspec/fontspec.pdf), but there must be a trailing slash in the file path for `XeTeX` to find the font.