### PR TITLE
Allow to use 'none' for an employment's end date

### DIFF
--- a/examples/resume.yaml
+++ b/examples/resume.yaml
@@ -6,7 +6,7 @@ employments:
   - company: Acme Corp
     title: Code monkey
     start: 2017-01
-    end: 2019-09
+    end: none
     keywords:
       - foo
       - bar

--- a/examples/resume.yaml
+++ b/examples/resume.yaml
@@ -14,11 +14,22 @@ employments:
     points:
       - Lorem Ipsum is simply dummy text of the printing and typesetting industry.
       - Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.
+  - company: Tyrell Corp
+    title: Mechanic
+    start: 2016-09
+    end: 2016-12
+    keywords:
+      - assembly
+    points:
+      - I've seen things you people wouldn't believe.
+      - Attack ships on fire off the shoulder of Orion.
+      - I watched C-beams glitter in the dark near the Tannhäuser Gate.
+      - All those moments will be lost in time, like tears in rain.
 educations:
   - institution: Mars Univeristy
     title: dfg.gf.gdf.dfg.gdf.dgf
-    start: 2017-01
-    end: 2017-01
+    start: 2013-10
+    end: 2016-07
 skills:
   - name: Web
     keywords:

--- a/src/models/employment.rs
+++ b/src/models/employment.rs
@@ -1,25 +1,80 @@
 use crate::serializers::date_serializer;
 use chrono::NaiveDate;
-use serde::Deserialize;
+use serde::de;
+use serde::{Deserialize, Deserializer};
+use std::fmt;
+
+#[derive(Debug, Clone)]
+pub struct StartDate(NaiveDate);
+
+#[derive(Debug, Clone)]
+pub enum EndDate {
+    None,
+    Date(NaiveDate),
+}
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Employment {
     pub(crate) company: String,
     pub(crate) title: String,
-    #[serde(with = "date_serializer")]
-    pub(crate) start: NaiveDate,
-    #[serde(with = "date_serializer")]
-    pub(crate) end: NaiveDate,
+    #[serde(deserialize_with = "deserialize_start_date")]
+    pub(crate) start: StartDate,
+    #[serde(deserialize_with = "deserialize_end_date")]
+    pub(crate) end: EndDate,
     pub(crate) keywords: Vec<String>,
     pub(crate) points: Vec<String>,
 }
 
 impl Employment {
     pub(crate) fn duration(&self) -> String {
-        format!(
-            "{} - {}",
-            self.start.format("%b %Y"),
-            self.end.format("%b %Y")
-        )
+        format!("{} - {}", self.start, self.end)
     }
+}
+
+impl fmt::Display for StartDate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0.format("%b %Y"))
+    }
+}
+
+impl fmt::Display for EndDate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::None => write!(f, "present"),
+            Self::Date(date) => write!(f, "{}", date.format("%b %Y")),
+        }
+    }
+}
+
+fn deserialize_start_date<'de, D>(deserializer: D) -> Result<StartDate, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    date_serializer::deserialize(deserializer).map(StartDate)
+}
+
+fn deserialize_end_date<'de, D>(deserializer: D) -> Result<EndDate, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct EndDateVisitor;
+
+    impl<'de> de::Visitor<'de> for EndDateVisitor {
+        type Value = EndDate;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a date or the string 'none'")
+        }
+
+        fn visit_str<E: de::Error>(self, s: &str) -> Result<Self::Value, E> {
+            match s {
+                "none" => Ok(Self::Value::None),
+                _ => date_serializer::deserialize_str(&s)
+                    .map(EndDate::Date)
+                    .map_err(serde::de::Error::custom),
+            }
+        }
+    }
+
+    deserializer.deserialize_str(EndDateVisitor)
 }

--- a/tests/fixtures/expected.html
+++ b/tests/fixtures/expected.html
@@ -61,10 +61,10 @@
                 <textarea class="form-control" rows="1" readonly id=title__0>Code monkey</textarea>
             </div>
             <div class="form-group">
-                <textarea class="form-control" rows="1" readonly id=start__0>2017-01-01</textarea>
+                <textarea class="form-control" rows="1" readonly id=start__0>Jan 2017</textarea>
             </div>
             <div class="form-group">
-                <textarea class="form-control" rows="1" readonly id=end__0>2019-09-01</textarea>
+                <textarea class="form-control" rows="1" readonly id=end__0>present</textarea>
             </div>
             
             <div class="form-group">

--- a/tests/fixtures/expected.html
+++ b/tests/fixtures/expected.html
@@ -90,6 +90,43 @@
             
         </form>
         
+        <form class="employment" id=employment__1>
+            <div class="form-group">
+                <textarea class="form-control" rows="1" readonly id=company__1>Tyrell Corp</textarea>
+            </div>
+            <div class="form-group">
+                <textarea class="form-control" rows="1" readonly id=title__1>Mechanic</textarea>
+            </div>
+            <div class="form-group">
+                <textarea class="form-control" rows="1" readonly id=start__1>Sep 2016</textarea>
+            </div>
+            <div class="form-group">
+                <textarea class="form-control" rows="1" readonly id=end__1>Dec 2016</textarea>
+            </div>
+            
+            <div class="form-group">
+                <textarea class="form-control" rows="1" readonly>assembly</textarea>
+            </div>
+            
+            
+            <div class="form-group">
+                <textarea class="form-control" rows="1" readonly>I've seen things you people wouldn't believe.</textarea>
+            </div>
+            
+            <div class="form-group">
+                <textarea class="form-control" rows="1" readonly>Attack ships on fire off the shoulder of Orion.</textarea>
+            </div>
+            
+            <div class="form-group">
+                <textarea class="form-control" rows="1" readonly>I watched C-beams glitter in the dark near the Tannhäuser Gate.</textarea>
+            </div>
+            
+            <div class="form-group">
+                <textarea class="form-control" rows="1" readonly>All those moments will be lost in time, like tears in rain.</textarea>
+            </div>
+            
+        </form>
+        
     </div>
 </div>
             <hr>
@@ -123,10 +160,10 @@
                 <textarea class="form-control" rows="1" readonly>dfg.gf.gdf.dfg.gdf.dgf</textarea>
             </div>
             <div class="form-group">
-                <textarea class="form-control" rows="1" readonly>2017-01-01</textarea>
+                <textarea class="form-control" rows="1" readonly>2013-10-01</textarea>
             </div>
             <div class="form-group">
-                <textarea class="form-control" rows="1" readonly>2017-01-01</textarea>
+                <textarea class="form-control" rows="1" readonly>2016-07-01</textarea>
             </div>
         </form>
         

--- a/tests/fixtures/expected.tex
+++ b/tests/fixtures/expected.tex
@@ -36,7 +36,7 @@
 \section{Employment}
 
 \begin{description}
-    \item [Acme Corp] Code monkey, Jan 2017 - Sep 2019
+    \item [Acme Corp] Code monkey, Jan 2017 - present
     \item [\footnotesize{
      foo,  bar,  baz 
     }]

--- a/tests/fixtures/expected.tex
+++ b/tests/fixtures/expected.tex
@@ -49,13 +49,31 @@
     
 \end{itemize}
 
+\begin{description}
+    \item [Tyrell Corp] Mechanic, Sep 2016 - Dec 2016
+    \item [\footnotesize{
+     assembly 
+    }]
+\end{description}
+\begin{itemize}
+    
+    \item I've seen things you people wouldn't believe.
+    
+    \item Attack ships on fire off the shoulder of Orion.
+    
+    \item I watched C-beams glitter in the dark near the Tannhäuser Gate.
+    
+    \item All those moments will be lost in time, like tears in rain.
+    
+\end{itemize}
+
 \section{Education}
 
 \begin{description}
     \item [Mars Univeristy]
 \end{description}
 \begin{itemize}
-    \item dfg.gf.gdf.dfg.gdf.dgf, 2017 - 2017
+    \item dfg.gf.gdf.dfg.gdf.dgf, 2013 - 2016
 \end{itemize}
 
 \end{leftcolumn}


### PR DESCRIPTION
Use this if the employment is still ongoing.